### PR TITLE
Fix reference to project.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main":             "index.js",
     "repository":       {
         "type": "git",
-        "url":  "git+https://github.com/jordansexton/koa-heartbeat.git"
+        "url":  "git+https://github.com/jordansexton/react-native-wkwebview.git"
     },
     "keywords":         [
         "react",


### PR DESCRIPTION
Could you publish a new version of this package? The listing in the npm registry (https://www.npmjs.com/package/react-native-wkwebview) indicates that https://github.com/jordansexton/koa-heartbeat is the home page for this project.

I initially thought it was a fraudulent listing until I pulled down the code itself from npm and found a reference to the correct location.